### PR TITLE
feat(web): dev-only UI component playground (bl-d319)

### DIFF
--- a/.oat/repo/reference/backlog/index.md
+++ b/.oat/repo/reference/backlog/index.md
@@ -10,7 +10,7 @@
 <!-- OAT BACKLOG-INDEX -->
 | ID | Title | Status | Priority | Scope | Estimate |
 | --- | --- | --- | --- | --- | --- |
-| bl-d319 | Dev-only UI component playground for fast UI iteration | open | medium | task | S |
+| bl-d319 | Dev-only UI component playground for fast UI iteration | in_progress | medium | task | S |
 | bl-821f | Explore symbolic Sequence board rendering | open | medium | feature | M |
 <!-- END OAT BACKLOG-INDEX -->
 

--- a/.oat/repo/reference/backlog/index.md
+++ b/.oat/repo/reference/backlog/index.md
@@ -6,12 +6,14 @@
 
 - `bl-821f` captures a follow-up visual exploration for a more physical-board-like game surface; keep it separate from the current card-cropping hotfix.
 - `bl-d319` is a DX follow-up to add a dev-only UI playground for fast component iteration; deferred out of the web-mvp final PR to keep it focused. Cheap given components are already prop-driven with a single `GameSnapshotView` shape, and its fixtures would seed a future Storybook adoption.
+- `bl-b0e7` is the deferred Storybook evaluation that `bl-d319` references — a planning/go-no-go item, not a commitment. Low priority while the `/dev` playground covers fast iteration; revisit if we want richer controls, a11y, or visual-regression testing. Designed to reuse the same `game-fixtures.ts` fixtures so there is no duplication if we adopt it.
 
 <!-- OAT BACKLOG-INDEX -->
 | ID | Title | Status | Priority | Scope | Estimate |
 | --- | --- | --- | --- | --- | --- |
 | bl-d319 | Dev-only UI component playground for fast UI iteration | in_progress | medium | task | S |
 | bl-821f | Explore symbolic Sequence board rendering | open | medium | feature | M |
+| bl-b0e7 | Evaluate and adopt Storybook for web UI components | open | low | feature | M |
 <!-- END OAT BACKLOG-INDEX -->
 
 ## Notes

--- a/.oat/repo/reference/backlog/items/adopt-storybook-web-ui.md
+++ b/.oat/repo/reference/backlog/items/adopt-storybook-web-ui.md
@@ -1,0 +1,166 @@
+---
+id: bl-b0e7
+title: 'Evaluate and adopt Storybook for web UI components'
+status: open # open | in_progress | closed | wont_do
+priority: low # urgent | high | medium | low | none
+scope: feature # idea | task | feature | initiative
+scope_estimate: M # XS | S | M | L | XL | XXL
+labels: [web, game-ui, dx, tooling, storybook]
+assignee: null
+created: '2026-06-21T18:55:00.000Z'
+updated: '2026-06-21T18:55:00.000Z'
+associated_issues: []
+oat_template: false
+oat_template_name: backlog-item
+---
+
+## Description
+
+Outline what it would take to adopt [Storybook](https://storybook.js.org/) for
+the web app's UI and game components, so we can make an informed go/no-go
+decision later. This is a **planning + evaluation** item, not a commitment to
+ship Storybook. If we do proceed, this item should contain enough detail to be
+executed without re-deriving the design.
+
+### Why this exists (and why it was deferred)
+
+The dev-only `/dev` component playground (`bl-d319`) was the lightweight option
+chosen for fast UI iteration: no new build tooling, reuses the prod
+Tailwind/font/Next pipeline, and previews are pixel-identical to production.
+Storybook was considered and intentionally deferred to keep the web MVP focused
+and to avoid a second, parallel rendering/build pipeline before we knew we
+needed one.
+
+The groundwork is already favorable:
+
+- Leaf components are pure and fully prop-driven (`GameBoard`, `CardHand`,
+  `PlayerRail`, `LobbyTeams`, `GameOver`, `HandoffScreen`, and the
+  `Button`/`Card`/`Badge` primitives).
+- There is a single source-of-truth state shape (`GameSnapshotView` in
+  `apps/web/src/app/game/[id]/components/game-state.ts`).
+- A shared fixtures module already exists
+  (`apps/web/src/app/game/[id]/components/game-fixtures.ts`) and was explicitly
+  designed to be reusable as Storybook story args, not just by `/dev` and tests.
+
+So the open question is not "can we" but "is the added tooling worth it" — and
+if yes, exactly how to wire it without fighting Next.js 16 (App Router /
+Turbopack), Tailwind v4 (CSS-configured `@theme`), and our `.ts`/`.tsx`
+extension-in-import convention.
+
+### What adoption would look like
+
+The following is a concrete sketch of the implementation so the evaluation has
+real substance. Treat it as a proposed design to validate, not settled fact.
+
+#### 1. Tooling and dependencies
+
+- Use the **`@storybook/nextjs`** (or `@storybook/nextjs-vite`) framework so
+  Storybook reuses our Next config, the `next/image` component, `next/font`,
+  and the `@/*` path alias rather than re-implementing them. Pin to a Storybook
+  major that supports **Next.js 16** and **React 19**; verify compatibility
+  before committing (Storybook's Next framework historically lags new Next
+  majors by weeks — this is the single biggest adoption risk).
+- Decide builder: Webpack5 (matches `@storybook/nextjs`) vs. Vite
+  (`@storybook/nextjs-vite`). Vite is faster and closer to our Vitest setup,
+  but the Next framework integration is less battle-tested. Spike both.
+- Dev/CI-only dependency footprint; nothing ships in the production bundle.
+- Co-locate Storybook config at `apps/web/.storybook/` (`main.ts`,
+  `preview.tsx`), scoped to the `@sequence/web` workspace — not the monorepo
+  root — so it only sees web components.
+
+#### 2. Global decorators / parameters (`preview.tsx`)
+
+- Import `apps/web/src/app/globals.css` so the Tailwind v4 `@theme` tokens
+  (`--color-slate`, `--color-team-*`, `bg-cream`, etc.) and base body styles
+  load exactly as in production. This is the key to visual fidelity and the same
+  guarantee the `/dev` playground makes today.
+- Wire `next/font` the same way `app/layout.tsx` does so typography matches.
+- Provide a decorator that supplies any context a component needs in isolation
+  (e.g. a no-op/mock `TRPCReactProvider`, router context). Most leaf components
+  need none, mirroring how `/dev` renders them, but the wrapper keeps stories
+  that touch providers from crashing.
+- Set sensible `parameters` (viewport presets for mobile/desktop game layouts,
+  backgrounds matching `cream`/`slate`/`felt`).
+
+#### 3. Stories sourced from the existing fixtures
+
+- Add `*.stories.tsx` co-located with each component under
+  `apps/web/src/...`, OR a central `apps/web/src/stories/` tree — decide based
+  on whether we want stories next to source (better locality) or isolated
+  (cleaner prod tree). Co-location is the Storybook-recommended default.
+- **Reuse `game-fixtures.ts` directly** as story `args`. Each representative
+  `GameSnapshotView` (lobby, active/your-turn, active/not-your-turn, dead-card,
+  sequence-choice, game-over) becomes a named story. This is the payoff of the
+  fixtures being pipeline-agnostic — no fixture duplication between `/dev`,
+  tests, and Storybook.
+- Cover the same surface the `/dev` playground covers: board, hand, player rail,
+  lobby teams, game-over, handoff, and the `Button`/`Card`/`Badge` primitives
+  (with their variants/sizes/tones via Storybook `argTypes` controls).
+- Use the CSF3 (Component Story Format 3) `Meta`/`StoryObj` typing so stories
+  are type-checked by `tsgo`.
+
+#### 4. Interaction, a11y, and visual testing (optional add-ons)
+
+- `@storybook/addon-a11y` to surface accessibility regressions per story.
+- `@storybook/addon-interactions` + the test runner to assert behavior (e.g.
+  tap-to-select highlights valid targets) directly against stories.
+- Visual regression: either Storybook's own test runner with snapshots, or an
+  external service (Chromatic). Chromatic is the lowest-effort path but is a
+  paid/3rd-party dependency — flag as a separate decision.
+- Evaluate whether Storybook interaction tests should **replace or complement**
+  the existing Vitest + Testing Library tests, to avoid maintaining two test
+  styles for the same components.
+
+#### 5. Scripts, CI, and build hygiene
+
+- Add `storybook` (dev) and `build-storybook` (static export) scripts to
+  `apps/web/package.json`.
+- Ensure `build-storybook` output (`storybook-static/`) is gitignored and not
+  published to users; if we want a hosted reference, deploy it as a separate
+  artifact, not part of the app.
+- Wire `build-storybook` into CI as a build smoke test (catches broken stories)
+  without blocking the main app build.
+- Keep `tsgo` typecheck and `oxlint`/`oxfmt` covering `*.stories.tsx`
+  (extension-in-import convention applies).
+
+#### 6. Relationship to the `/dev` playground
+
+- Decide the end state: (a) Storybook **replaces** `/dev`, (b) both coexist
+  (`/dev` for in-app/prod-pipeline fidelity, Storybook for richer
+  controls/a11y/visual testing), or (c) `/dev` is retired once Storybook proves
+  out. Document the decision and migration path either way.
+- Because both consume the same `game-fixtures.ts`, migration is mostly moving
+  the per-component "stories" rendering logic from
+  `apps/web/src/app/dev/_playground/stories.tsx` into CSF story files.
+
+### Open questions to resolve during evaluation
+
+- Does a Storybook release support Next 16 + React 19 + Turbopack today, or do
+  we pin to Webpack5 builder?
+- Is Tailwind v4 (`@theme` in CSS, PostCSS plugin) fully picked up by the chosen
+  builder without extra config?
+- Do we accept a second build pipeline's maintenance cost vs. the `/dev` route?
+- Do we want Chromatic (paid) for visual regression, or self-host snapshots?
+- One test framework or two (Storybook interactions vs. Vitest/Testing Library)?
+
+## Acceptance Criteria
+
+- A documented evaluation (in this item or a linked decision record) of whether
+  to adopt Storybook, covering: Next 16 / React 19 / Tailwind v4 compatibility,
+  builder choice (Webpack5 vs. Vite), and the maintenance trade-off vs. the
+  existing `/dev` playground.
+- A concrete, ordered implementation plan that, if approved, can be executed
+  without re-researching: dependencies + versions, `.storybook/main.ts` and
+  `preview.tsx` outline, global decorators (Tailwind/`globals.css`, fonts,
+  mock providers), and story file layout/convention.
+- Confirmation that stories would reuse the existing `game-fixtures.ts`
+  `GameSnapshotView` fixtures (no fixture duplication across `/dev`, tests, and
+  Storybook), with the representative states enumerated.
+- A defined relationship/migration path between Storybook and the existing
+  `/dev` playground (replace, coexist, or retire `/dev`).
+- Build/CI hygiene defined: dev + `build-storybook` scripts, `storybook-static`
+  excluded from the shipped product, and a CI story-build smoke check.
+- A decision on optional add-ons (a11y addon, interaction/visual-regression
+  testing, Chromatic vs. self-hosted) with rationale.
+- A go/no-go recommendation with rough effort sizing, so the team can schedule
+  or close the item.

--- a/.oat/repo/reference/backlog/items/dev-ui-component-playground.md
+++ b/.oat/repo/reference/backlog/items/dev-ui-component-playground.md
@@ -1,14 +1,14 @@
 ---
 id: bl-d319
 title: 'Dev-only UI component playground for fast UI iteration'
-status: open # open | in_progress | closed | wont_do
+status: in_progress # open | in_progress | closed | wont_do
 priority: medium # urgent | high | medium | low | none
 scope: task # idea | task | feature | initiative
 scope_estimate: S # XS | S | M | L | XL | XXL
 labels: [web, game-ui, dx, tooling]
 assignee: null
 created: '2026-06-21T15:10:31.000Z'
-updated: '2026-06-21T15:10:31.000Z'
+updated: '2026-06-21T18:38:00.000Z'
 associated_issues: []
 oat_template: false
 oat_template_name: backlog-item

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -59,11 +59,44 @@ Playwright lives in `apps/web/e2e`. It loads the root `.env`, requires
 `DATABASE_URL_TEST`, and starts API/web servers on `127.0.0.1` with a fixed test
 auth secret.
 
+## Component Playground (`/dev`)
+
+A dev-only UI playground renders the reusable UI and game components in
+isolation across their key visual states — no login, no live tRPC
+subscription. It reuses the production Tailwind/typography pipeline, so previews
+are visually faithful to what ships.
+
+Open it by running the app and visiting [`/dev`](http://localhost:3000/dev):
+
+```bash
+pnpm --filter @sequence/web dev   # then open http://localhost:3000/dev
+```
+
+The whole `/dev` subtree is gated on `process.env.NODE_ENV !== 'production'`
+(see `src/app/dev/layout.tsx`), so it 404s and never ships to users.
+
+How it is wired:
+
+- **Fixtures** — `src/app/game/[id]/components/game-fixtures.ts` exports
+  representative `GameSnapshotView` states (lobby, active/your-turn,
+  active/not-your-turn, dead-card, sequence-choice, game-over). These are shared
+  by the playground and by tests (see `game-fixtures.test.ts`).
+- **Sections** — `src/app/dev/_playground/sections.ts` lists the nav entries;
+  `stories.tsx` maps each section slug to a renderer that drives the real
+  components from the fixtures.
+
+To add a component or state:
+
+1. Add or extend a fixture in `game-fixtures.ts` (and surface it via
+   `gameFixtures` if it is a new snapshot state).
+2. Add a renderer in `_playground/stories.tsx` and a matching entry in
+   `_playground/sections.ts` (the `slug` must match the `STORIES` key).
+
 ## Game UI Notes
 
 The game route uses `GameSnapshotView` plus streamed events from
 `components/game-state.ts`. Leaf components are prop-driven and should stay
-usable from tests or future fixture-driven playgrounds.
+usable from tests or the fixture-driven playground (see above).
 
 The board currently uses full card SVGs from `public/cards` and renders them
 with `object-fit: contain`. A symbolic/physical-board rendering direction is a

--- a/apps/web/src/app/dev/[section]/page.tsx
+++ b/apps/web/src/app/dev/[section]/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { notFound, useParams } from 'next/navigation';
+
+import { getSectionMeta } from '../_playground/sections.ts';
+import { STORIES } from '../_playground/stories.tsx';
+
+/** Renders the previews for a single playground section. */
+export default function DevSectionPage() {
+  const params = useParams<{ section: string }>();
+  const slug = params.section;
+  const meta = getSectionMeta(slug);
+  const Story = STORIES[slug];
+  if (!meta || !Story) {
+    notFound();
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-2xl font-black text-black">{meta.title}</h2>
+        <p className="max-w-2xl text-sm text-black/60">{meta.blurb}</p>
+      </header>
+      <Story />
+    </div>
+  );
+}

--- a/apps/web/src/app/dev/_playground/sections.ts
+++ b/apps/web/src/app/dev/_playground/sections.ts
@@ -1,0 +1,56 @@
+/**
+ * Playground section catalog.
+ *
+ * Plain, serializable metadata so the server `layout`/index can render the nav
+ * without pulling in the client-only story components. The matching renderers
+ * live in `stories.tsx`, keyed by the same `slug`.
+ */
+export interface PlaygroundSectionMeta {
+  slug: string;
+  title: string;
+  blurb: string;
+}
+
+export const SECTIONS: PlaygroundSectionMeta[] = [
+  {
+    slug: 'primitives',
+    title: 'Primitives',
+    blurb: 'Button, Card, and Badge across variants, sizes, and tones.',
+  },
+  {
+    slug: 'board',
+    title: 'Game board',
+    blurb: 'GameBoard driven by fixtures, with selection and win highlighting.',
+  },
+  {
+    slug: 'hand',
+    title: 'Card hand',
+    blurb: 'CardHand fan in tap and drag modes, including dead cards.',
+  },
+  {
+    slug: 'player-rail',
+    title: 'Player rail',
+    blurb: 'PlayerRail turn order, timers, sequence counts, and disconnects.',
+  },
+  {
+    slug: 'lobby',
+    title: 'Lobby teams',
+    blurb: 'LobbyTeams seat assignment across player counts.',
+  },
+  {
+    slug: 'handoff',
+    title: 'Handoff',
+    blurb: 'Pass-and-play handoff screen between local turns.',
+  },
+  {
+    slug: 'game-over',
+    title: 'Game over',
+    blurb: 'GameOver summary for wins and concessions.',
+  },
+];
+
+export function getSectionMeta(
+  slug: string,
+): PlaygroundSectionMeta | undefined {
+  return SECTIONS.find((section) => section.slug === slug);
+}

--- a/apps/web/src/app/dev/_playground/stage.tsx
+++ b/apps/web/src/app/dev/_playground/stage.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+type StageBackground = 'cream' | 'slate' | 'felt' | 'white';
+
+const BACKGROUNDS: Record<StageBackground, string> = {
+  cream: 'bg-cream',
+  slate: 'bg-slate',
+  felt: 'bg-felt',
+  white: 'bg-white',
+};
+
+export interface StageProps {
+  title: string;
+  description?: string;
+  /** Surface behind the preview, matching where the component lives in prod. */
+  background?: StageBackground;
+  children: ReactNode;
+}
+
+/**
+ * Frames a single preview variant: a caption plus a production-faithful
+ * surface (same Tailwind tokens as the live app) so the rendered component is
+ * pixel-identical to what ships.
+ */
+export function Stage({
+  title,
+  description,
+  background = 'cream',
+  children,
+}: StageProps) {
+  return (
+    <figure className="overflow-hidden rounded-xl border border-black/10 bg-white">
+      <figcaption className="flex flex-col gap-0.5 border-b border-black/10 px-4 py-2">
+        <span className="text-sm font-bold text-black">{title}</span>
+        {description ? (
+          <span className="text-xs text-black/55">{description}</span>
+        ) : null}
+      </figcaption>
+      <div className={`${BACKGROUNDS[background]} flex justify-center p-4`}>
+        {children}
+      </div>
+    </figure>
+  );
+}
+
+/** Vertical stack of stages for a section page. */
+export function StageGrid({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-6">{children}</div>;
+}

--- a/apps/web/src/app/dev/_playground/stories.tsx
+++ b/apps/web/src/app/dev/_playground/stories.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import { CardHand } from '@/app/game/[id]/components/CardHand/CardHand.tsx';
+import {
+  createTapSelection,
+  deadCardIndexes,
+} from '@/app/game/[id]/components/controllers/tap-controller.ts';
+import {
+  getGameFixture,
+  winningSequenceCells,
+} from '@/app/game/[id]/components/game-fixtures.ts';
+import { GameBoard } from '@/app/game/[id]/components/GameBoard/GameBoard.tsx';
+import { GameOver } from '@/app/game/[id]/components/GameOver/GameOver.tsx';
+import { HandoffScreen } from '@/app/game/[id]/components/HandoffScreen/HandoffScreen.tsx';
+import { LobbyTeams } from '@/app/game/[id]/components/LobbyTeams/LobbyTeams.tsx';
+import { PlayerRail } from '@/app/game/[id]/components/PlayerRail/PlayerRail.tsx';
+import { Badge } from '@/components/badge.tsx';
+import { Button } from '@/components/button.tsx';
+import { Card } from '@/components/card.tsx';
+
+import { Stage, StageGrid } from './stage.tsx';
+
+const noop = () => {};
+
+/** Fixture lookup that throws loudly if a slug drifts out of sync. */
+function fixture(id: string) {
+  const found = getGameFixture(id);
+  if (!found) throw new Error(`missing fixture: ${id}`);
+  return found.snapshot;
+}
+
+function PrimitivesStory() {
+  return (
+    <StageGrid>
+      <Stage
+        title="Button — variants"
+        description="primary / secondary / ghost / danger"
+      >
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="primary">Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="danger">Danger</Button>
+          <Button variant="primary" disabled>
+            Disabled
+          </Button>
+        </div>
+      </Stage>
+      <Stage title="Button — sizes" description="md / lg">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+        </div>
+      </Stage>
+      <Stage title="Card" background="cream">
+        <Card className="w-full max-w-sm">
+          <p className="text-sm font-bold text-black">Surface container</p>
+          <p className="mt-1 text-sm text-black/60">
+            Cream/white surface used across dashboard, history, and join.
+          </p>
+        </Card>
+      </Stage>
+      <Stage
+        title="Badge — tones"
+        description="frozen / saved / neutral / win / loss"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge tone="frozen">Frozen</Badge>
+          <Badge tone="saved">Saved</Badge>
+          <Badge tone="neutral">Neutral</Badge>
+          <Badge tone="win">Win</Badge>
+          <Badge tone="loss">Loss</Badge>
+        </div>
+      </Stage>
+    </StageGrid>
+  );
+}
+
+function InteractiveBoard() {
+  const snapshot = fixture('active-your-turn');
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const selection = createTapSelection({
+    hand: snapshot.hand,
+    board: snapshot.board,
+    team: snapshot.teams[snapshot.mySeat] ?? 1,
+    selectedIndex,
+  });
+  return (
+    <div className="flex w-full max-w-2xl flex-col items-center gap-3">
+      <GameBoard
+        board={snapshot.board}
+        validTargets={selection?.validTargets}
+        onCellSelect={noop}
+      />
+      <CardHand
+        hand={snapshot.hand}
+        mode="tap"
+        selectedIndex={selectedIndex}
+        onSelectCard={(_, index) =>
+          setSelectedIndex((current) => (current === index ? null : index))
+        }
+      />
+      <p className="text-xs text-black/55">
+        Tap a card to preview its valid targets on the board.
+      </p>
+    </div>
+  );
+}
+
+function BoardStory() {
+  const choice = fixture('sequence-choice');
+  const finished = fixture('game-over');
+  return (
+    <StageGrid>
+      <Stage title="Active — tap to highlight targets">
+        <InteractiveBoard />
+      </Stage>
+      <Stage
+        title="Sequence choice"
+        description="Overline run pending the locking five"
+      >
+        <div className="w-full max-w-2xl">
+          <GameBoard
+            board={choice.board}
+            pendingChoiceCells={choice.pendingChoice?.cells}
+            choiceSelectedCells={choice.pendingChoice?.cells.slice(0, 5)}
+          />
+        </div>
+      </Stage>
+      <Stage title="Game over — winning cells">
+        <div className="w-full max-w-2xl">
+          <GameBoard
+            board={finished.board}
+            winningCells={winningSequenceCells}
+          />
+        </div>
+      </Stage>
+    </StageGrid>
+  );
+}
+
+function HandStory() {
+  const active = fixture('active-your-turn');
+  const dead = fixture('dead-card');
+  return (
+    <StageGrid>
+      <Stage title="Tap mode" background="felt">
+        <div className="w-full max-w-xl">
+          <CardHand hand={active.hand} mode="tap" onSelectCard={noop} />
+        </div>
+      </Stage>
+      <Stage title="Tap mode — dead card dimmed" background="felt">
+        <div className="w-full max-w-xl">
+          <CardHand
+            hand={dead.hand}
+            mode="tap"
+            deadCardIndexes={deadCardIndexes(dead.hand, dead.board)}
+            onSelectCard={noop}
+          />
+        </div>
+      </Stage>
+      <Stage title="Drag mode" background="felt">
+        <div className="w-full max-w-xl">
+          <CardHand
+            hand={active.hand}
+            mode="drag"
+            onCardDragStart={noop}
+            onCardDragEnd={noop}
+          />
+        </div>
+      </Stage>
+    </StageGrid>
+  );
+}
+
+function PlayerRailStory() {
+  const yourTurn = fixture('active-your-turn');
+  const noTimer = fixture('active-not-your-turn');
+  const finished = fixture('game-over');
+  return (
+    <StageGrid>
+      <Stage title="Active — timed turn">
+        <div className="w-full max-w-3xl">
+          <PlayerRail
+            players={yourTurn.players}
+            currentSeat={yourTurn.currentSeat}
+            round={yourTurn.round}
+            sequences={yourTurn.sequences}
+            lastPlayedCards={{ 1: { rank: 'K', suit: 'H' } }}
+            timerSeconds={yourTurn.timerSeconds}
+            turnRemainingMs={yourTurn.turnRemainingMs}
+            status={yourTurn.status}
+            nowMs={0}
+          />
+        </div>
+      </Stage>
+      <Stage title="Active — no timer, opponent on the clock">
+        <div className="w-full max-w-3xl">
+          <PlayerRail
+            players={noTimer.players}
+            currentSeat={noTimer.currentSeat}
+            round={noTimer.round}
+            sequences={noTimer.sequences}
+            timerSeconds={null}
+            status={noTimer.status}
+            nowMs={0}
+          />
+        </div>
+      </Stage>
+      <Stage title="Finished — sequence counts">
+        <div className="w-full max-w-3xl">
+          <PlayerRail
+            players={finished.players}
+            currentSeat={finished.currentSeat}
+            round={finished.round}
+            sequences={finished.sequences}
+            timerSeconds={null}
+            status={finished.status}
+            nowMs={0}
+          />
+        </div>
+      </Stage>
+    </StageGrid>
+  );
+}
+
+function LobbyStory() {
+  const lobby = fixture('lobby');
+  return (
+    <StageGrid>
+      <Stage title="Four players, no timer">
+        <div className="w-full max-w-2xl">
+          <LobbyTeams
+            inviteCode={lobby.inviteCode}
+            playerCount={4}
+            mode={lobby.mode}
+            timerSeconds={null}
+            players={lobby.players}
+            mySeat={lobby.mySeat}
+            onJoinTeam={noop}
+            onKick={noop}
+            onRandomize={noop}
+            onStart={noop}
+            onCopyInvite={noop}
+          />
+        </div>
+      </Stage>
+      <Stage title="Two players, 30s turn timer">
+        <div className="w-full max-w-2xl">
+          <LobbyTeams
+            inviteCode={lobby.inviteCode}
+            playerCount={2}
+            mode="drag"
+            timerSeconds={30}
+            players={lobby.players.slice(0, 2)}
+            mySeat={lobby.mySeat}
+            onJoinTeam={noop}
+            onKick={noop}
+            onRandomize={noop}
+            onStart={noop}
+            onCopyInvite={noop}
+          />
+        </div>
+      </Stage>
+    </StageGrid>
+  );
+}
+
+function HandoffStory() {
+  return (
+    <StageGrid>
+      <Stage title="With last move" background="cream">
+        <div className="w-full max-w-md">
+          <HandoffScreen
+            playerName="Marcus"
+            lastMoveLabel="KH to 1KH"
+            onReveal={noop}
+          />
+        </div>
+      </Stage>
+      <Stage title="First turn (no last move)" background="cream">
+        <div className="w-full max-w-md">
+          <HandoffScreen playerName="Riya" onReveal={noop} />
+        </div>
+      </Stage>
+    </StageGrid>
+  );
+}
+
+function GameOverStory() {
+  const finished = fixture('game-over');
+  return (
+    <StageGrid>
+      <Stage title="Win">
+        <div className="w-full max-w-2xl">
+          <GameOver
+            winnerTeam={finished.winnerTeam}
+            endReason="win"
+            players={finished.players}
+            onRematch={noop}
+          />
+        </div>
+      </Stage>
+      <Stage title="Conceded">
+        <div className="w-full max-w-2xl">
+          <GameOver
+            winnerTeam={null}
+            endReason="concede"
+            concededTeam={2}
+            players={finished.players}
+            onRematch={noop}
+          />
+        </div>
+      </Stage>
+    </StageGrid>
+  );
+}
+
+/** Section slug → renderer. Keys must match `sections.ts`. */
+export const STORIES: Record<string, () => ReactNode> = {
+  primitives: PrimitivesStory,
+  board: BoardStory,
+  hand: HandStory,
+  'player-rail': PlayerRailStory,
+  lobby: LobbyStory,
+  handoff: HandoffStory,
+  'game-over': GameOverStory,
+};

--- a/apps/web/src/app/dev/layout.tsx
+++ b/apps/web/src/app/dev/layout.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+import { SECTIONS } from './_playground/sections.ts';
+
+export const metadata = {
+  title: 'UI Playground · Sequence',
+};
+
+/**
+ * Dev-only component playground shell.
+ *
+ * Gated on `NODE_ENV` so the entire `/dev` subtree 404s in production builds
+ * and never ships to users. The nav lists each preview section; pages render
+ * the real components driven by shared fixtures — no auth guard, no tRPC.
+ */
+export default function DevLayout({ children }: { children: ReactNode }) {
+  if (process.env.NODE_ENV === 'production') {
+    notFound();
+  }
+
+  return (
+    <div className="bg-cream text-slate min-h-screen">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4 sm:flex-row sm:p-6">
+        <aside className="sm:w-56 sm:shrink-0">
+          <Link href="/dev" className="block">
+            <p className="text-xs font-black tracking-wide text-black/45 uppercase">
+              Dev only
+            </p>
+            <h1 className="text-lg font-black text-black">UI Playground</h1>
+          </Link>
+          <nav className="mt-4 flex flex-col gap-1">
+            {SECTIONS.map((section) => (
+              <Link
+                key={section.slug}
+                href={`/dev/${section.slug}`}
+                className="text-slate rounded-lg px-3 py-2 text-sm font-semibold hover:bg-black/5"
+              >
+                {section.title}
+              </Link>
+            ))}
+          </nav>
+        </aside>
+        <main className="min-w-0 flex-1">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dev/page.tsx
+++ b/apps/web/src/app/dev/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+import { SECTIONS } from './_playground/sections.ts';
+
+/** Playground landing: overview and links into each preview section. */
+export default function DevIndexPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <h2 className="text-2xl font-black text-black">Component playground</h2>
+        <p className="max-w-2xl text-sm text-black/60">
+          Render the shared UI and game components in isolation across their key
+          visual states — no login, no live game subscription. Previews use the
+          production Tailwind/typography pipeline, so they are visually faithful
+          to what ships. This subtree is excluded from production builds.
+        </p>
+      </header>
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {SECTIONS.map((section) => (
+          <li key={section.slug}>
+            <Link
+              href={`/dev/${section.slug}`}
+              className="block h-full rounded-xl border border-black/10 bg-white p-4 shadow-sm hover:border-black/25"
+            >
+              <p className="text-sm font-bold text-black">{section.title}</p>
+              <p className="mt-1 text-xs text-black/55">{section.blurb}</p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/app/game/[id]/components/game-fixtures.test.ts
+++ b/apps/web/src/app/game/[id]/components/game-fixtures.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { deadCardIndexes } from './controllers/tap-controller.ts';
+import { gameFixtures, getGameFixture } from './game-fixtures.ts';
+import { screenForState, stateFromSnapshot } from './game-state.ts';
+
+describe('game fixtures', () => {
+  it('covers the representative states from the backlog item', () => {
+    const ids = gameFixtures.map((fixture) => fixture.id);
+    expect(ids).toEqual([
+      'lobby',
+      'active-your-turn',
+      'active-not-your-turn',
+      'dead-card',
+      'sequence-choice',
+      'game-over',
+    ]);
+  });
+
+  it('projects each fixture into a routable view state', () => {
+    expect(screenForState(stateFromSnapshot(getFixture('lobby')))).toBe(
+      'lobby',
+    );
+    expect(
+      screenForState(stateFromSnapshot(getFixture('active-your-turn'))),
+    ).toBe('game');
+    expect(screenForState(stateFromSnapshot(getFixture('game-over')))).toBe(
+      'game-over',
+    );
+  });
+
+  it('flags the live-turn fixture as the local seat’s turn', () => {
+    const yours = getFixture('active-your-turn');
+    const theirs = getFixture('active-not-your-turn');
+    expect(yours.currentSeat).toBe(yours.mySeat);
+    expect(theirs.currentSeat).not.toBe(theirs.mySeat);
+  });
+
+  it('makes a real dead card in the dead-card fixture', () => {
+    const fixture = getFixture('dead-card');
+    expect(deadCardIndexes(fixture.hand, fixture.board).length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('carries a completed winning sequence in the game-over fixture', () => {
+    const fixture = getFixture('game-over');
+    expect(fixture.winnerTeam).toBe(1);
+    expect(fixture.sequences).toHaveLength(1);
+    for (const cell of fixture.sequences[0]!.cells) {
+      expect(fixture.board[cell]?.lockedBy).toBe(fixture.sequences[0]!.id);
+    }
+  });
+});
+
+function getFixture(id: string) {
+  const fixture = getGameFixture(id);
+  if (!fixture) throw new Error(`missing fixture: ${id}`);
+  return fixture.snapshot;
+}

--- a/apps/web/src/app/game/[id]/components/game-fixtures.ts
+++ b/apps/web/src/app/game/[id]/components/game-fixtures.ts
@@ -1,0 +1,268 @@
+import type { Card, Position, Team } from '@sequence/game-logic';
+
+import type {
+  GameSnapshotView,
+  SnapshotBoardCell,
+  SnapshotPlayer,
+  SnapshotSequence,
+} from './game-state.ts';
+
+/**
+ * Representative {@link GameSnapshotView} states for fast, isolated UI work.
+ *
+ * These fixtures feed the dev playground (`/dev`) and are equally usable from
+ * component tests, so previews and assertions exercise the same shapes the live
+ * game route projects from snapshots + streamed events. They intentionally use
+ * real board position codes (see `@sequence/game-logic` `BOARD_MAP`) so the
+ * board, dead-card detection, and sequence highlighting behave faithfully.
+ */
+
+const PLAYERS: SnapshotPlayer[] = [
+  {
+    seat: 0,
+    team: 1,
+    name: 'You',
+    isCreator: true,
+    isGuest: false,
+    connected: true,
+  },
+  {
+    seat: 1,
+    team: 2,
+    name: 'Riya',
+    isCreator: false,
+    isGuest: false,
+    connected: true,
+  },
+  {
+    seat: 2,
+    team: 1,
+    name: 'Marcus',
+    isCreator: false,
+    isGuest: false,
+    connected: true,
+  },
+  {
+    seat: 3,
+    team: 2,
+    name: 'Lena',
+    isCreator: false,
+    isGuest: true,
+    connected: true,
+  },
+];
+
+/**
+ * A six-card hand spanning the interesting display cases: a normal number card
+ * (`5C`, which the dead-card fixture covers on the board), a two-eyed wild jack
+ * (`JD`), a one-eyed removal jack (`JS`), and ordinary cards.
+ */
+const HAND: Card[] = [
+  { rank: '5', suit: 'C' },
+  { rank: 'T', suit: 'H' },
+  { rank: 'J', suit: 'D' },
+  { rank: 'J', suit: 'S' },
+  { rank: '7', suit: 'S' },
+  { rank: 'Q', suit: 'D' },
+];
+
+/** Merge several `{ position: cell }` groups into one board record. */
+function board(
+  ...groups: Record<Position, SnapshotBoardCell>[]
+): Record<Position, SnapshotBoardCell> {
+  return Object.assign({}, ...groups);
+}
+
+/** Place same-team chips on a set of positions. */
+function chips(
+  team: Team,
+  ...positions: Position[]
+): Record<Position, SnapshotBoardCell> {
+  return Object.fromEntries(
+    positions.map((position) => [position, { chip: team }]),
+  );
+}
+
+/** Place locked (sequence-completed) chips for a team. */
+function lockedChips(
+  team: Team,
+  sequenceId: number,
+  ...positions: Position[]
+): Record<Position, SnapshotBoardCell> {
+  return Object.fromEntries(
+    positions.map((position) => [
+      position,
+      { chip: team, lockedBy: sequenceId },
+    ]),
+  );
+}
+
+/** Mid-game scatter shared by the active fixtures. */
+const ACTIVE_BOARD = board(
+  chips(1, '1AC', '1KC', '1QC'),
+  chips(2, '17S', '18S', '2TC'),
+);
+
+/** The winning sequence used by the game-over fixture (top-row run + corner). */
+const WINNING_CELLS: Position[] = ['1WW', '1AC', '1KC', '1QC', '1TC'];
+
+const WINNING_SEQUENCE: SnapshotSequence = {
+  id: 1,
+  team: 1,
+  cells: WINNING_CELLS,
+};
+
+function baseSnapshot(): GameSnapshotView {
+  return {
+    gameId: 'dev-game',
+    inviteCode: 'DEV123',
+    status: 'active',
+    playerCount: 4,
+    mode: 'tap',
+    timerSeconds: null,
+    local: false,
+    mySeat: 0,
+    currentSeat: 0,
+    round: 3,
+    version: 12,
+    board: {},
+    sequences: [],
+    players: PLAYERS,
+    teams: [1, 2, 1, 2],
+    hand: HAND,
+  };
+}
+
+const lobby: GameSnapshotView = {
+  ...baseSnapshot(),
+  status: 'lobby',
+  round: 0,
+  version: 0,
+  board: {},
+  hand: [],
+};
+
+const activeYourTurn: GameSnapshotView = {
+  ...baseSnapshot(),
+  status: 'active',
+  currentSeat: 0,
+  board: ACTIVE_BOARD,
+  timerSeconds: 30,
+  turnRemainingMs: 21_000,
+};
+
+const activeNotYourTurn: GameSnapshotView = {
+  ...baseSnapshot(),
+  status: 'active',
+  currentSeat: 1,
+  board: ACTIVE_BOARD,
+  timerSeconds: 30,
+  turnRemainingMs: 8_000,
+};
+
+/**
+ * Both board copies of `5C` (`15C`, `25C`) are covered, so the `5C` held in
+ * {@link HAND} is dead and renders dimmed in the hand fan.
+ */
+const deadCard: GameSnapshotView = {
+  ...baseSnapshot(),
+  status: 'active',
+  currentSeat: 0,
+  board: board(ACTIVE_BOARD, chips(2, '15C'), chips(1, '25C')),
+};
+
+/**
+ * An overline: six chips in a row let the player choose which five lock into a
+ * sequence. `placed` marks the cell just played.
+ */
+const sequenceChoice: GameSnapshotView = {
+  ...baseSnapshot(),
+  status: 'active',
+  currentSeat: 0,
+  board: board(chips(1, '1WW', '1AC', '1KC', '1QC', '1TC', '19C')),
+  pendingChoice: {
+    seat: 0,
+    cells: ['1WW', '1AC', '1KC', '1QC', '1TC', '19C'],
+    placed: '19C',
+  },
+};
+
+const gameOver: GameSnapshotView = {
+  ...baseSnapshot(),
+  status: 'finished',
+  currentSeat: 0,
+  board: board(
+    ACTIVE_BOARD,
+    lockedChips(1, WINNING_SEQUENCE.id, ...WINNING_CELLS),
+  ),
+  sequences: [WINNING_SEQUENCE],
+  winner: 1,
+  winnerTeam: 1,
+};
+
+export interface GameFixture {
+  /** Stable slug used in playground routes and fixture lookups. */
+  id: string;
+  /** Human label for menus and preview captions. */
+  label: string;
+  /** One-line note on what the state demonstrates. */
+  description: string;
+  snapshot: GameSnapshotView;
+}
+
+/**
+ * The representative fixtures, in narrative order (lobby → play → end). Add a
+ * new entry here to surface it in both the playground and any fixture-driven
+ * test.
+ */
+export const gameFixtures: GameFixture[] = [
+  {
+    id: 'lobby',
+    label: 'Lobby',
+    description: 'Pre-game lobby with teams forming and no board yet.',
+    snapshot: lobby,
+  },
+  {
+    id: 'active-your-turn',
+    label: 'Active — your turn',
+    description:
+      'Mid-game, it is the local seat’s turn with time on the clock.',
+    snapshot: activeYourTurn,
+  },
+  {
+    id: 'active-not-your-turn',
+    label: 'Active — not your turn',
+    description: 'Mid-game while an opponent is on the clock.',
+    snapshot: activeNotYourTurn,
+  },
+  {
+    id: 'dead-card',
+    label: 'Dead card',
+    description: 'Both board copies of a held card are covered, so it is dead.',
+    snapshot: deadCard,
+  },
+  {
+    id: 'sequence-choice',
+    label: 'Sequence choice',
+    description: 'An overline run prompts the player to pick the locking five.',
+    snapshot: sequenceChoice,
+  },
+  {
+    id: 'game-over',
+    label: 'Game over',
+    description: 'Finished game with a completed, locked winning sequence.',
+    snapshot: gameOver,
+  },
+];
+
+const fixturesById: Record<string, GameFixture> = Object.fromEntries(
+  gameFixtures.map((fixture) => [fixture.id, fixture]),
+);
+
+/** Look up a single fixture by id. */
+export function getGameFixture(id: string): GameFixture | undefined {
+  return fixturesById[id];
+}
+
+/** The winning sequence cells, exported for board highlighting in previews. */
+export const winningSequenceCells = WINNING_CELLS;


### PR DESCRIPTION
## Summary

Implements backlog item **bl-d319** — a lightweight, dev-only UI playground so reusable UI and game components can be rendered in isolation across their key visual states, without going through account login, a live tRPC subscription, or real game plumbing.

Open it by running the web app and visiting [`/dev`](http://localhost:3000/dev).

## What's included

- **Shared fixtures module** (`apps/web/src/app/game/[id]/components/game-fixtures.ts`) — exports representative `GameSnapshotView` states (`lobby`, `active-your-turn`, `active-not-your-turn`, `dead-card`, `sequence-choice`, `game-over`) using real board position codes, so dead-card detection and sequence highlighting behave faithfully. Reusable from both the playground and tests.
- **`/dev` routes** (`apps/web/src/app/dev/`) — render the real components (board, hand, player rail, lobby teams, game-over, handoff, and the `Button`/`Card`/`Badge` primitives) driven by the fixtures. No auth guard, no live subscription. Includes an interactive board+hand that highlights valid targets via the real tap controller.
- **Production gate** — the whole `/dev` subtree is gated on `process.env.NODE_ENV !== 'production'` (`layout.tsx` calls `notFound()`), so it 404s in prod and never ships.
- **Faithful previews** — reuses the production Tailwind/typography pipeline (`globals.css`, real components), no new build tooling.
- **Docs** — README section on how to open the playground and add a component/state.

## Acceptance criteria

- [x] Shared fixtures module exports representative `GameSnapshotView` states, reusable from playground and tests
- [x] Dev-only `/dev` routes render real components driven by fixtures, no auth guard / no live tRPC
- [x] Excluded from production builds (gated on `NODE_ENV !== 'production'`)
- [x] Previews use the same Tailwind/typography pipeline as production
- [x] Developer docs/README note on opening the playground and adding a component/state

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @sequence/web typecheck` | ✅ clean |
| `pnpm --filter @sequence/web test` | ✅ 103 pass (5 new) |
| `pnpm lint` / `pnpm format:check` | ✅ clean |
| Dev server | ✅ all `/dev` routes 200; invalid section 404s |
| Production build | ✅ builds clean; `/dev*` routes return **404** in prod while normal routes (e.g. `/login`) return 200 |

Backlog item `bl-d319` flipped to `in_progress`.